### PR TITLE
startBinauralSimulator.m: use addPathsIfNotIncluded, which is much fa…

### DIFF
--- a/src/startBinauralSimulator.m
+++ b/src/startBinauralSimulator.m
@@ -26,6 +26,6 @@ clear docNode eleList % Clear used variables
 %% add necessary paths
 basePath = [fileparts(mfilename('fullpath')) filesep];
 
-addpath([basePath 'mex']);
+addPathsIfNotIncluded([basePath 'mex']);
 
 clear basePath;  % Clear used variables


### PR DESCRIPTION
For some reasons, addpath can get ridiculously slow in subsequent calls. This can be fixed by checking whether the path to be added already IS on the path manually: my new function addPathsIfNotIncluded does exactly this. Speed improvement for startTwoEars on our server: 1 min down do 1 second.