### PR TITLE
buffer.FIFO.removeData speed fix

### DIFF
--- a/src/+simulator/+buffer/FIFO.m
+++ b/src/+simulator/+buffer/FIFO.m
@@ -43,7 +43,7 @@ classdef FIFO < simulator.buffer.Data
         elseif length > size(obj.data,1)
           obj.data = [];
         else
-          obj.data(1:length,:) = [];
+          obj.data = obj.data(length+1:end,:);
         end
       end
     end


### PR DESCRIPTION
FIFO.removeData took about 70% of the whole simulation time. With this fix, removeData's speed is duplicated and simulation time thus relieved by about 35%.

@fietew , @hagenw , please verify that functionality is still the same and also the speedup.