### PR TITLE
add alternative url for database

### DIFF
--- a/src/+db/url.m
+++ b/src/+db/url.m
@@ -1,23 +1,36 @@
-function url = url(url)
+function [url, alturl] = url(url, alturl)
 % defines url of root directory of remote twoears database.
 %
 % Parameters:
-%   url:  url of root directory of remote twoears database, optional @type char[]
+%   url:      url of root directory of remote twoears database, optional @type 
+%             char[]
+%   alturl:   alternative url 
 %
 % Return values:
-%   url:  current url
+%   url:      current url
+%   alturl:   current alternative url
 %
 % defines root path to local copy of twoears database. Calling this function
-% without an argument just returns the current url. Taken from SOFA
+% without an argument just returns the current url. Inspired from SOFA
 % (http://www.sofaconventions.org/). 
 %
 % See also: http://sourceforge.net/p/sofacoustics/code/HEAD/tree/trunk/API_MO/SOFAdbURL.m
 
 persistent CachedURL;
+persistent CachedAltURL;
 
+% URL
 if exist('url','var')
   CachedURL=url;
 elseif isempty(CachedURL)
-  CachedURL= 'https://dev.qu.tu-berlin.de/projects/twoears-database/repository/revisions/master/raw/';
+  CachedURL= 'https://dev.qu.tu-berlin.de/projects/twoears-getdata/repository/raw/';
 end
 url=CachedURL;
+
+% Alternative URL
+if exist('alturl','var')
+  CachedAltURL=alturl;
+elseif isempty(CachedAltURL)
+  CachedAltURL= 'https://dev.qu.tu-berlin.de/projects/twoears-database/repository/revisions/master/raw/';
+end
+alturl=CachedAltURL;


### PR DESCRIPTION
Follow up to TWOEARS/documentation#42:

@TWOEARS/all :
The Two!Ears public database has been moved to a new location. The default URL for the interface has been updated accordingly. As the directory tree of the new database slightly differs from the old one, some files might be unreachable. For compatibility reasons, I added an alternative database URL to the API, which is by default the URL to the old public database. If the file does not exist in the new database a warning is given and the API tries to get the file from the old database. Long story short, besides some warnings everything should work as before. However, I would like to encourage you to check your code, where the database API is used.